### PR TITLE
Use truthy check instead of null check

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ const output = getInput("package-path", { required: true });
 const projectFolder = getInput("project-folder", { required: false }) ?? "./";
 const includeFilesPath = getInput("include-files", { required: true });
 
-if (workingFolder != null) {
+if (workingFolder) {
   chdir(workingFolder);
 }
 


### PR DESCRIPTION
`getInput()` function in `@actions/core` seems to return empty string for an unspecified option, so `workingFolder != null` may not work as intended. 
https://github.com/actions/toolkit/blob/master/packages/core/src/core.ts#L69-L77